### PR TITLE
improvement(config.webpack): make fully customizable options 

### DIFF
--- a/packages/config.webpack/README.md
+++ b/packages/config.webpack/README.md
@@ -9,14 +9,51 @@ Base configuration for Webpack
 | Option    | Type      | Default |
 | --------- | --------- | ------- |
 | sourceMap | _Boolean_ | `true`  |
+| additionalEntry | _Array_ | `[]` |
+| moduleFileExtensions | _Array_ | `[]` |
+| jsFileExtensions | _Array_ | `[]` |
+| paths | _Object_ | |
+| paths.root | _String_ | ` ` |
+| paths.src | _String_ | `src` |
+| paths.build | _String_ | `build` |
+| paths.indexJs | _String_ | `src/index` |
+| paths.indexHtml | _String_ | `public/index.html` |
+| paths.public | _String_ | `public` |
 
 ## Passing options
 
+### Example
+
+Turn off source maps
+
+#### `package.json`
+
 ```
 {
+  ...
   "zero-scripts": {
     "@zero-scripts/config.webpack": {
       "sourceMap": false
+    }
+  }
+}
+```
+
+### Example
+
+Sources are in root directory
+
+#### `package.json`
+
+```
+{
+  ...
+  "zero-scripts": {
+    "@zero-scripts/config.webpack": {
+      "paths": {
+         "src": "",
+         "indexJs": "index"
+      }
     }
   }
 }

--- a/packages/config.webpack/src/WebpackConfigOptions.ts
+++ b/packages/config.webpack/src/WebpackConfigOptions.ts
@@ -1,6 +1,6 @@
 export type WebpackConfigOptions = {
   isDev: boolean;
-  entry: string[];
+  additionalEntry: string[];
   moduleFileExtensions: string[];
   jsFileExtensions: string[];
   sourceMap: boolean;

--- a/packages/config.webpack/src/index.ts
+++ b/packages/config.webpack/src/index.ts
@@ -1,2 +1,3 @@
 export * from './WebpackConfig';
 export * from './WebpackConfigOptions';
+export * from './utils';

--- a/packages/config.webpack/src/utils/index.ts
+++ b/packages/config.webpack/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getRootDir';
+export * from './resolvePath';
+export * from './resolveModule';

--- a/packages/config.webpack/src/utils/resolveModule.ts
+++ b/packages/config.webpack/src/utils/resolveModule.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import { resolvePath } from './resolvePath';
+
+export const resolveModule = (extensions: string[], relativePath: string) => {
+  const extension = extensions.find(extension =>
+    fs.existsSync(resolvePath(`${relativePath}.${extension}`))
+  );
+
+  if (extension) {
+    return resolvePath(`${relativePath}.${extension}`);
+  }
+
+  return resolvePath(`${relativePath}.js`);
+};

--- a/packages/extension.webpack-babel/src/index.ts
+++ b/packages/extension.webpack-babel/src/index.ts
@@ -1,5 +1,6 @@
 import { AbstractExtension } from '@zero-scripts/core';
 import { WebpackConfig } from '@zero-scripts/config.webpack';
+import { resolvePath } from '@zero-scripts/config.webpack';
 
 export type WebpackBabelExtensionOptions = {
   presets: string[];
@@ -18,7 +19,7 @@ export class WebpackBabelExtension extends AbstractExtension<
           oneOf: [
             {
               test,
-              include: paths.src,
+              include: resolvePath(paths.src),
               use: {
                 loader: require.resolve('babel-loader'),
                 options: {

--- a/packages/extension.webpack-eslint/src/index.ts
+++ b/packages/extension.webpack-eslint/src/index.ts
@@ -1,12 +1,13 @@
 import { AbstractExtension, InsertPos } from '@zero-scripts/core';
 import { WebpackConfig } from '@zero-scripts/config.webpack';
+import { resolvePath } from '@zero-scripts/config.webpack';
 
 export class WebpackEslintExtension extends AbstractExtension {
   public activate(): void {
     this.preset.getInstance(WebpackConfig).insertModuleRule(
       ({ jsFileExtensions, paths }) => ({
         test: new RegExp(`\\.(${jsFileExtensions.join('|')})$`),
-        include: paths.src,
+        include: resolvePath(paths.src),
         enforce: 'pre',
         use: [
           {

--- a/packages/preset.webpack-spa/src/extensions/addCleanWebpackPlugin.ts
+++ b/packages/preset.webpack-spa/src/extensions/addCleanWebpackPlugin.ts
@@ -1,11 +1,15 @@
-import { WebpackConfig } from '@zero-scripts/config.webpack';
+import { resolvePath, WebpackConfig } from '@zero-scripts/config.webpack';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 
 export const addCleanWebpackPlugin = (config: WebpackConfig) =>
   config.insertPlugin(({ isDev, paths }) =>
     !isDev
       ? new CopyWebpackPlugin([
-          { from: paths.public, to: paths.build, ignore: [paths.indexHtml] }
+          {
+            from: resolvePath(paths.public),
+            to: resolvePath(paths.build),
+            ignore: [resolvePath(paths.indexHtml)]
+          }
         ])
       : undefined
   );

--- a/packages/preset.webpack-spa/src/extensions/addCopyWebpackPlugin.ts
+++ b/packages/preset.webpack-spa/src/extensions/addCopyWebpackPlugin.ts
@@ -1,9 +1,11 @@
-import { WebpackConfig } from '@zero-scripts/config.webpack';
+import { resolvePath, WebpackConfig } from '@zero-scripts/config.webpack';
 import CleanWebpackPlugin from 'clean-webpack-plugin';
 
 export const addCopyWebpackPlugin = (config: WebpackConfig) =>
   config.insertPlugin(({ isDev, paths }) =>
     !isDev
-      ? new CleanWebpackPlugin([paths.build], { allowExternal: true })
+      ? new CleanWebpackPlugin([resolvePath(paths.build)], {
+          allowExternal: true
+        })
       : undefined
   );

--- a/packages/preset.webpack-spa/src/extensions/addHtmlWebpackPlugin.ts
+++ b/packages/preset.webpack-spa/src/extensions/addHtmlWebpackPlugin.ts
@@ -1,4 +1,4 @@
-import { WebpackConfig } from '@zero-scripts/config.webpack';
+import { resolvePath, WebpackConfig } from '@zero-scripts/config.webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { InsertPos } from '@zero-scripts/core';
 
@@ -7,7 +7,7 @@ export const addHtmlWebpackPlugin = (config: WebpackConfig) =>
     ({ isDev, paths }) =>
       new HtmlWebpackPlugin({
         inject: true,
-        template: paths.indexHtml,
+        template: resolvePath(paths.indexHtml),
         minify: !isDev
           ? {
               removeComments: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6416,7 +6416,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7188,7 +7188,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8145,6 +8145,14 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -8300,6 +8308,26 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-dom@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
+  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.12.0"
+
+react@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
+  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.12.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -8814,6 +8842,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
+  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@^0.4.4:
   version "0.4.7"


### PR DESCRIPTION
`paths` not resolved in constructor, now need do this manually when you access this option in extensions; this change allow correctness change paths before build configuration

add api methods to add extension to jsFileExtension parameter

now using `resolveModule` for resolving `src/index` with no concrete extension

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
